### PR TITLE
Language Code REGEX dit not match first language

### DIFF
--- a/Tambula.php
+++ b/Tambula.php
@@ -239,7 +239,7 @@ class Tambula{
 	public function findLanguageCodes(bool $findFirst = false){
 		// Find all two letter language codes in HTTP_ACCEPT_LANGUAGE string
 		$acceptedLang = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
-		$pattern = '/,([a-z]{2})/';
+		$pattern = '/([a-z]{2})/';
 		preg_match_all($pattern, $acceptedLang, $matches);
 
 		// Find only first


### PR DESCRIPTION
In a language string for example `en,nl;q=0.9` only `nl` was matched because `en` is not preceeed by `,`.